### PR TITLE
Work around `yarn install` spuriously restarting on M1 Macs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ WORKDIR /app
 
 COPY . .
 
-RUN yarn install
+# Big packages cause false network connectivity alarms: https://github.com/yarnpkg/yarn/issues/4890
+RUN yarn install --network-timeout 1000000
 
 RUN yarn next build
 


### PR DESCRIPTION
When working with DOCKER_DEFAULT_PLATFORM=linux/amd64 on M1 Macs, performance
is degraded due to required Qemu usage.  This cases network throughput to slow
down and so `yarn install` often treats slow progress as a network error,
resetting the transfer, making it doubly slow.

This simple change, as documented on Yarn's bug tracker, removes the overly
eager network reset.