### PR TITLE
Refactor api routes methods handling, auth and safe error checking to a helper function

### DIFF
--- a/pages-common/apiHandler.ts
+++ b/pages-common/apiHandler.ts
@@ -1,0 +1,52 @@
+import {NextApiRequest, NextApiResponse} from "next";
+import {handleExceptions} from "./handleExceptions";
+import {AuthContext, readJWTBearer} from "./auth";
+
+type APIHandler = (req: NextApiRequest, res: NextApiResponse) => Promise<void>;
+
+type MethodHandler = APIHandler | {handler: APIHandler; noAuth?: boolean};
+
+export function createAPIHandler(methodHandlers: {
+  GET?: MethodHandler;
+  POST?: MethodHandler;
+  PATCH?: MethodHandler;
+  PUT?: MethodHandler;
+  DELETE?: MethodHandler;
+}): APIHandler {
+  const handlers: {[key: string]: {handler: APIHandler; noAuth: boolean}} = {};
+  for (const [method, handler] of Object.entries(methodHandlers)) {
+    handlers[method] =
+      typeof handler === "function"
+        ? {handler, noAuth: false}
+        : {...handler, noAuth: handler.noAuth ?? false};
+  }
+
+  return async (req: NextApiRequest, res: NextApiResponse) => {
+    const methodHandler = handlers[req.method!];
+
+    if (!methodHandler) {
+      return res.status(405).end(`method ${req.method} not allowed`);
+    }
+
+    // Auth can be disabled on a per method basis because some admin api
+    // routes can still be public:
+    // for example those that return the list of agreements (GET),
+    // even though cherry-picking endpoints that require authentication is
+    // not the best developer's UX.
+    if (!methodHandler.noAuth) {
+      /**
+       * Requires an authenticated user for an API request. Inspects request
+       * headers to look for a valid JWT Bearer token. Stops request handling
+       * and returns 401 for unauthorized users.
+       */
+      try {
+        const user = await readJWTBearer(req);
+        (req as unknown as AuthContext).user = user;
+      } catch (err: any) {
+        return res.status(401).end(err);
+      }
+    }
+
+    await handleExceptions(res, () => methodHandler.handler(req, res));
+  };
+}

--- a/pages-common/auth.ts
+++ b/pages-common/auth.ts
@@ -18,7 +18,7 @@ function getMessageForError(error: Error): string {
   return "Unauthorized";
 }
 
-function readJWTBearer(req: NextApiRequest): Promise<object> {
+export function readJWTBearer(req: NextApiRequest): Promise<object> {
   return new Promise((resolve, reject) => {
     const authorization = req.headers.authorization;
 
@@ -45,35 +45,5 @@ function readJWTBearer(req: NextApiRequest): Promise<object> {
     }
 
     resolve(identity);
-  });
-}
-
-// NB: the function below is coded like in the official documentation
-// middlewares example (2020.06.04).
-// This is convenient because some admin api routes can still be public:
-// for example those that return the list of agreements (GET),
-// even though cherry-picking endpoints that require authentication is
-// not the best developer's UX.
-
-/**
- * Requires an authenticated user for an API request. Inspects request headers
- * to look for a valid JWT Bearer token. Stops request handling and returns
- * 401 for unauthorized users.
- */
-export function auth(
-  req: NextApiRequest,
-  res: NextApiResponse
-): Promise<object> {
-  return new Promise((resolve, reject) => {
-    readJWTBearer(req).then(
-      (user) => {
-        (req as unknown as AuthContext).user = user;
-        resolve(user);
-      },
-      (error) => {
-        res.status(401).end(error);
-        reject(error);
-      }
-    );
   });
 }

--- a/pages-common/handleExceptions.ts
+++ b/pages-common/handleExceptions.ts
@@ -1,0 +1,26 @@
+import {NextApiResponse} from "next";
+import {ErrorDetails, SafeError} from "../service/common/web";
+
+/**
+ * Executes a given function, handling any thrown SafeError to serve
+ * useful information to the client, in case of error.
+ *
+ * The error class is called "SafeError" because its purpose is to provide
+ * error details to the client, unlike unhandled exceptions.
+ */
+export async function handleExceptions<T>(
+  res: NextApiResponse<T | ErrorDetails>,
+  action: () => Promise<void>
+): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    if (error instanceof SafeError) {
+      // handled error: the service is behaving as desired
+      res.status(error.statusCode).json(error.getObject());
+      return;
+    }
+
+    throw error;
+  }
+}

--- a/pages/api/administrators/[id]/index.ts
+++ b/pages/api/administrators/[id]/index.ts
@@ -1,36 +1,24 @@
-import {auth} from "../../../../pages-common/auth";
 import {container} from "../../../../service/di";
-import {NextApiRequest, NextApiResponse} from "next";
 import {TYPES} from "../../../../constants/types";
 import {AdministratorsHandler} from "../../../../service/handlers/administrators";
-import {handleExceptions} from "../../";
+import {createAPIHandler} from "../../../../pages-common/apiHandler";
 
 const administratorsHandler = container.get<AdministratorsHandler>(
   TYPES.AdministratorsHandler
 );
 
-export default async (req: NextApiRequest, res: NextApiResponse<any>) => {
-  await auth(req, res);
+export default createAPIHandler({
+  DELETE: async (req, res) => {
+    const {
+      query: {id},
+    } = req;
 
-  const {
-    query: {id},
-  } = req;
+    if (typeof id !== "string") {
+      // should never happen by definition
+      return res.status(400).end("Invalid object id");
+    }
 
-  if (typeof id !== "string") {
-    // should never happen by definition
-    return res.status(400).end("Invalid object id");
-  }
-
-  const {method} = req;
-
-  switch (method) {
-    case "DELETE":
-      await handleExceptions(res, async () => {
-        await administratorsHandler.removeAdministrator(id);
-        return res.status(204).end();
-      });
-      return;
-  }
-
-  res.status(405).end(`${method} not allowed`);
-};
+    await administratorsHandler.removeAdministrator(id);
+    return res.status(204).end();
+  },
+});

--- a/pages/api/administrators/auth/github/callback.ts
+++ b/pages/api/administrators/auth/github/callback.ts
@@ -1,11 +1,10 @@
 import githubAuth from "./configuration";
 import {NextApiRequest, NextApiResponse} from "next";
-import {SafeError} from "../../../../../service/common/web";
 import {readOAuthError} from "../../../../../pages-common/oauth";
 import {AdministratorsHandler} from "../../../../../service/handlers/administrators";
 import {container} from "../../../../../service/di";
 import {TYPES} from "../../../../../constants/types";
-import {handleExceptions} from "../../../";
+import {handleExceptions} from "../../../../../pages-common/handleExceptions";
 
 const administratorsHandler = container.get<AdministratorsHandler>(
   TYPES.AdministratorsHandler

--- a/pages/api/administrators/index.ts
+++ b/pages/api/administrators/index.ts
@@ -1,33 +1,21 @@
-import {auth} from "../../../pages-common/auth";
 import {container} from "../../../service/di";
-import {NextApiRequest, NextApiResponse} from "next";
 import {TYPES} from "../../../constants/types";
 import {AdministratorsHandler} from "../../../service/handlers/administrators";
-import {handleExceptions} from "..";
+import {createAPIHandler} from "../../../pages-common/apiHandler";
 
 const administratorsHandler = container.get<AdministratorsHandler>(
   TYPES.AdministratorsHandler
 );
 
-export default async (req: NextApiRequest, res: NextApiResponse<any>) => {
-  await auth(req, res);
+export default createAPIHandler({
+  GET: async (req, res) => {
+    const items = await administratorsHandler.getAdministrators();
+    res.status(200).json(items);
+  },
+  POST: async (req, res) => {
+    const {email} = req.body;
 
-  const {method} = req;
-
-  switch (method) {
-    case "GET":
-      const items = await administratorsHandler.getAdministrators();
-      res.status(200).json(items);
-      return;
-    case "POST":
-      await handleExceptions(res, async () => {
-        const {email} = req.body;
-
-        await administratorsHandler.addAdministrator(email);
-        return res.status(204).end();
-      });
-      return;
-  }
-
-  res.status(405).end(`${method} not allowed`);
-};
+    await administratorsHandler.addAdministrator(email);
+    return res.status(204).end();
+  },
+});

--- a/pages/api/administrators/me.ts
+++ b/pages/api/administrators/me.ts
@@ -1,10 +1,10 @@
-import {auth} from "../../../pages-common/auth";
-import {handleExceptions} from "..";
+import {AuthContext} from "../../../pages-common/auth";
 import {NextApiRequest, NextApiResponse} from "next";
+import {createAPIHandler} from "../../../pages-common/apiHandler";
 
-export default async (req: NextApiRequest, res: NextApiResponse) => {
-  await handleExceptions(res, async () => {
-    const user = await auth(req, res);
+export default createAPIHandler({
+  GET: async (req: NextApiRequest, res: NextApiResponse) => {
+    const user = (req as unknown as AuthContext).user;
     res.status(200).json(user);
-  });
-};
+  },
+});

--- a/pages/api/agreement-version/[id]/clone.ts
+++ b/pages/api/agreement-version/[id]/clone.ts
@@ -1,35 +1,27 @@
-import {auth} from "../../../../pages-common/auth";
 import {AgreementsHandler} from "../../../../service/handlers/agreements";
 import {container} from "../../../../service/di";
-import {handleExceptions} from "../..";
 import {NextApiRequest, NextApiResponse} from "next";
 import {TYPES} from "../../../../constants/types";
+import {createAPIHandler} from "../../../../pages-common/apiHandler";
 
 const agreementsHandler = container.get<AgreementsHandler>(
   TYPES.AgreementsHandler
 );
 
-export default async (req: NextApiRequest, res: NextApiResponse<any>) => {
-  await auth(req, res);
+export default createAPIHandler({
+  POST: async (req: NextApiRequest, res: NextApiResponse) => {
+    const {
+      query: {id},
+    } = req;
 
-  const {
-    query: {id},
-  } = req;
+    if (typeof id !== "string") {
+      // should never happen by definition
+      return res.status(400).end("Invalid object id");
+    }
 
-  if (typeof id !== "string") {
-    // should never happen by definition
-    return res.status(400).end("Invalid object id");
-  }
-
-  switch (req.method) {
-    case "POST":
-      // updates the text of an existing agreement version
-      // id is a version id;
-      await handleExceptions(res, async () => {
-        const newAgreement = await agreementsHandler.cloneAgreementVersion(id);
-        return res.status(200).json(newAgreement);
-      });
-  }
-
-  res.status(405).end(`${req.method} not allowed`);
-};
+    // updates the text of an existing agreement version
+    // id is a version id;
+    const newAgreement = await agreementsHandler.cloneAgreementVersion(id);
+    return res.status(200).json(newAgreement);
+  },
+});

--- a/pages/api/agreement-version/[id]/complete.ts
+++ b/pages/api/agreement-version/[id]/complete.ts
@@ -1,35 +1,27 @@
-import {auth} from "../../../../pages-common/auth";
 import {container} from "../../../../service/di";
 import {AgreementsHandler} from "../../../../service/handlers/agreements";
 import {NextApiRequest, NextApiResponse} from "next";
 import {TYPES} from "../../../../constants/types";
-import {handleExceptions} from "../..";
+import {createAPIHandler} from "../../../../pages-common/apiHandler";
 
 const agreementsHandler = container.get<AgreementsHandler>(
   TYPES.AgreementsHandler
 );
 
-export default async (req: NextApiRequest, res: NextApiResponse<any>) => {
-  await auth(req, res);
+export default createAPIHandler({
+  POST: async (req: NextApiRequest, res: NextApiResponse<any>) => {
+    const {
+      query: {id},
+    } = req;
 
-  const {
-    query: {id},
-  } = req;
+    if (typeof id !== "string") {
+      // should never happen by definition
+      return res.status(400).end("Invalid object id");
+    }
 
-  if (typeof id !== "string") {
-    // should never happen by definition
-    return res.status(400).end("Invalid object id");
-  }
-
-  switch (req.method) {
-    case "POST":
-      // updates the text of an existing agreement version
-      // id is a version id;
-      await handleExceptions(res, async () => {
-        await agreementsHandler.completeAgreementVersion(id);
-        return res.status(204).end();
-      });
-  }
-
-  res.status(405).end(`${req.method} not allowed`);
-};
+    // updates the text of an existing agreement version
+    // id is a version id;
+    await agreementsHandler.completeAgreementVersion(id);
+    return res.status(204).end();
+  },
+});

--- a/pages/api/agreement-version/[id]/index.ts
+++ b/pages/api/agreement-version/[id]/index.ts
@@ -4,26 +4,28 @@ import {AgreementsHandler} from "../../../../service/handlers/agreements";
 import {NextApiRequest, NextApiResponse} from "next";
 import {TYPES} from "../../../../constants/types";
 import {ErrorDetails} from "../../../../service/common/web";
+import {createAPIHandler} from "../../../../pages-common/apiHandler";
 
 const agreementsHandler = container.get<AgreementsHandler>(
   TYPES.AgreementsHandler
 );
 
-export default async (
-  req: NextApiRequest,
-  res: NextApiResponse<AgreementVersion | ErrorDetails | void>
-) => {
-  const {
-    query: {id},
-  } = req;
+export default createAPIHandler({
+  GET: {
+    noAuth: true,
+    handler: async (
+      req: NextApiRequest,
+      res: NextApiResponse<AgreementVersion | ErrorDetails | void>
+    ) => {
+      const {
+        query: {id},
+      } = req;
 
-  if (typeof id !== "string") {
-    // should never happen by definition
-    return res.status(400).end("Invalid object id");
-  }
+      if (typeof id !== "string") {
+        // should never happen by definition
+        return res.status(400).end("Invalid object id");
+      }
 
-  switch (req.method) {
-    case "GET":
       const data = await agreementsHandler.getAgreementVersion(id);
 
       if (!data) {
@@ -31,8 +33,6 @@ export default async (
       }
 
       res.status(200).json(data);
-      return;
-  }
-
-  res.status(405).end(`${req.method} not allowed`);
-};
+    },
+  },
+});

--- a/pages/api/agreement-version/[id]/make-current.ts
+++ b/pages/api/agreement-version/[id]/make-current.ts
@@ -1,35 +1,27 @@
-import {auth} from "../../../../pages-common/auth";
 import {container} from "../../../../service/di";
 import {AgreementsHandler} from "../../../../service/handlers/agreements";
 import {NextApiRequest, NextApiResponse} from "next";
 import {TYPES} from "../../../../constants/types";
-import {handleExceptions} from "../..";
+import {createAPIHandler} from "../../../../pages-common/apiHandler";
 
 const agreementsHandler = container.get<AgreementsHandler>(
   TYPES.AgreementsHandler
 );
 
-export default async (req: NextApiRequest, res: NextApiResponse<any>) => {
-  await auth(req, res);
+export default createAPIHandler({
+  POST: async (req: NextApiRequest, res: NextApiResponse) => {
+    const {
+      query: {id},
+    } = req;
 
-  const {
-    query: {id},
-  } = req;
+    if (typeof id !== "string") {
+      // should never happen by definition
+      return res.status(400).end("Invalid object id");
+    }
 
-  if (typeof id !== "string") {
-    // should never happen by definition
-    return res.status(400).end("Invalid object id");
-  }
-
-  switch (req.method) {
-    case "POST":
-      // updates the text of an existing agreement version
-      // id is a version id;
-      await handleExceptions(res, async () => {
-        await agreementsHandler.makeAgreementVersionCurrent(id);
-        return res.status(204).end();
-      });
-  }
-
-  res.status(405).end(`${req.method} not allowed`);
-};
+    // updates the text of an existing agreement version
+    // id is a version id;
+    await agreementsHandler.makeAgreementVersionCurrent(id);
+    return res.status(204).end();
+  },
+});

--- a/pages/api/agreements/[id]/index.ts
+++ b/pages/api/agreements/[id]/index.ts
@@ -1,56 +1,52 @@
-import {auth} from "../../../../pages-common/auth";
 import {AgreementsHandler} from "../../../../service/handlers/agreements";
 import {container} from "../../../../service/di";
-import {handleExceptions} from "../..";
 import {NextApiRequest, NextApiResponse} from "next";
 import {TYPES} from "../../../../constants/types";
+import {createAPIHandler} from "../../../../pages-common/apiHandler";
 
 const agreementsHandler = container.get<AgreementsHandler>(
   TYPES.AgreementsHandler
 );
 
-export default async (req: NextApiRequest, res: NextApiResponse<any>) => {
-  const {
-    query: {id},
-  } = req;
+export default createAPIHandler({
+  GET: {
+    noAuth: true,
+    handler: async (req: NextApiRequest, res: NextApiResponse) => {
+      const {
+        query: {id},
+      } = req;
 
-  if (typeof id !== "string") {
-    // should never happen by definition
-    return res.status(400).end("Invalid object id");
-  }
+      if (typeof id !== "string") {
+        // should never happen by definition
+        return res.status(400).end("Invalid object id");
+      }
 
-  switch (req.method) {
-    case "GET":
-      await handleExceptions(res, async () => {
-        const data = await agreementsHandler.getAgreement(id);
+      const data = await agreementsHandler.getAgreement(id);
 
-        if (data === null) {
-          return res.status(404).json({
-            error: "Agreement not found",
-            errorCode: "NotFound",
-          });
-        }
+      if (data === null) {
+        return res.status(404).json({
+          error: "Agreement not found",
+          errorCode: "NotFound",
+        });
+      }
 
-        res.status(200).json(data);
-      });
-      return;
-    case "PATCH":
-      await auth(req, res);
+      res.status(200).json(data);
+    },
+  },
+  PATCH: async (req, res) => {
+    const {
+      query: {id},
+    } = req;
 
-      // update an existing agreement
-      await handleExceptions(res, async () => {
-        const body = req.body;
+    if (typeof id !== "string") {
+      // should never happen by definition
+      return res.status(400).end("Invalid object id");
+    }
 
-        await agreementsHandler.updateAgreement(
-          id,
-          body.name,
-          body.description
-        );
+    const body = req.body;
 
-        return res.status(204).end();
-      });
-      return;
-  }
+    await agreementsHandler.updateAgreement(id, body.name, body.description);
 
-  res.status(405).end(`${req.method} not allowed`);
-};
+    res.status(204).end();
+  },
+});

--- a/pages/api/cla/index.ts
+++ b/pages/api/cla/index.ts
@@ -5,6 +5,7 @@ import {AgreementsHandler} from "../../../service/handlers/agreements";
 import {TYPES} from "../../../constants/types";
 import {ClaCheckInput} from "../../../service/domain/cla";
 import {ServerError} from "../../../service/common/app";
+import {createAPIHandler} from "../../../pages-common/apiHandler";
 
 interface ContributorLicenseAgreement {
   state: string;
@@ -13,44 +14,51 @@ interface ContributorLicenseAgreement {
 }
 
 // Returns a contributor license agreement text by state parameter
-export default async (
-  req: NextApiRequest,
-  res: NextApiResponse<ContributorLicenseAgreement>
-) => {
-  const rawState = req.query.state;
+export default createAPIHandler({
+  GET: {
+    noAuth: true,
+    handler: async (
+      req: NextApiRequest,
+      res: NextApiResponse<ContributorLicenseAgreement>
+    ) => {
+      const rawState = req.query.state;
 
-  if (typeof rawState !== "string") {
-    return res.status(400).end("Missing state parameter");
-  }
+      if (typeof rawState !== "string") {
+        return res.status(400).end("Missing state parameter");
+      }
 
-  const tokensHandler = container.get<TokensHandler>(TYPES.TokensHandler);
-  const licensesHandler = container.get<AgreementsHandler>(
-    TYPES.AgreementsHandler
-  );
+      const tokensHandler = container.get<TokensHandler>(TYPES.TokensHandler);
+      const licensesHandler = container.get<AgreementsHandler>(
+        TYPES.AgreementsHandler
+      );
 
-  const state = tokensHandler.parseToken(rawState) as ClaCheckInput;
+      const state = tokensHandler.parseToken(rawState) as ClaCheckInput;
 
-  // Read the current agreement for the PR repository
-  // Note: the page always fetches the current agreement text, regardless
-  // of thte time when the PR was created.
-  const agreementText = await licensesHandler.getAgreementTextForRepository(
-    state.repository.fullName,
-    "en"
-  );
+      // Read the current agreement for the PR repository
+      // Note: the page always fetches the current agreement text, regardless
+      // of thte time when the PR was created.
+      const agreementText =
+        await licensesHandler.getAgreementTextForRepository(
+          state.repository.fullName,
+          "en"
+        );
 
-  if (agreementText.versionId === null) {
-    // We need the agreement version id here, for the reason described below
-    throw new ServerError("Missing version id in agreement text context.");
-  }
+      if (agreementText.versionId === null) {
+        // We need the agreement version id here,
+        // for the reason described below
+        throw new ServerError("Missing version id in agreement text context.");
+      }
 
-  state.agreementVersionId = agreementText.versionId;
+      state.agreementVersionId = agreementText.versionId;
 
-  // Modify the state parameter to include the version id:
-  // this ensures that we store the right version id when the user signs in
-  // to agree
-  res.status(200).json({
-    state: tokensHandler.createToken(state),
-    text: agreementText.text,
-    title: agreementText.title,
-  });
-};
+      // Modify the state parameter to include the version id:
+      // this ensures that we store the right version id when the user signs in
+      // to agree
+      res.status(200).json({
+        state: tokensHandler.createToken(state),
+        text: agreementText.text,
+        title: agreementText.title,
+      });
+    },
+  },
+});

--- a/pages/api/clas/[email].ts
+++ b/pages/api/clas/[email].ts
@@ -1,39 +1,28 @@
 import {container} from "../../../service/di";
 import {NextApiRequest, NextApiResponse} from "next";
 import {TYPES} from "../../../constants/types";
-import {handleExceptions} from "..";
 import {ClasHandler} from "../../../service/handlers/clas";
-import {auth} from "../../../pages-common/auth";
+import {createAPIHandler} from "../../../pages-common/apiHandler";
 
 const clasHandler = container.get<ClasHandler>(TYPES.ClasHandler);
 
-export default async (req: NextApiRequest, res: NextApiResponse<any>) => {
-  await auth(req, res);
+export default createAPIHandler({
+  GET: async (req: NextApiRequest, res: NextApiResponse) => {
+    const {
+      query: {email},
+    } = req;
 
-  const {
-    query: {email},
-  } = req;
+    if (typeof email !== "string") {
+      // should never happen by definition
+      return res.status(400).end("Invalid email id");
+    }
 
-  if (typeof email !== "string") {
-    // should never happen by definition
-    return res.status(400).end("Invalid email id");
-  }
+    const data = await clasHandler.getClaByEmail(email);
 
-  switch (req.method) {
-    case "GET":
-      await handleExceptions(res, async () => {
-        const data = await clasHandler.getClaByEmail(email);
+    if (!data) {
+      return res.status(404).end("Object not found.");
+    }
 
-        if (!data) {
-          return res.status(404).end("Object not found.");
-        }
-
-        return res.status(200).json(data);
-      });
-
-      break;
-    default:
-      res.status(405).end(`${req.method} not allowed`);
-      break;
-  }
-};
+    return res.status(200).json(data);
+  },
+});

--- a/pages/api/clas/import.ts
+++ b/pages/api/clas/import.ts
@@ -1,32 +1,20 @@
 import {NextApiRequest, NextApiResponse} from "next";
-import {auth} from "../../../pages-common/auth";
 import {container} from "../../../service/di";
 import {TYPES} from "../../../constants/types";
 import {ClasImportOutput, ClasImportInput} from "../../../service/domain/cla";
-import {handleExceptions} from "..";
-import {ErrorDetails} from "../../../service/common/web";
 import {ClasHandler} from "../../../service/handlers/clas";
+import {createAPIHandler} from "../../../pages-common/apiHandler";
 
 const clasHandler = container.get<ClasHandler>(TYPES.ClasHandler);
 
-export default async (
-  req: NextApiRequest,
-  res: NextApiResponse<ClasImportOutput | ErrorDetails>
-) => {
-  await auth(req, res);
+export default createAPIHandler({
+  POST: async (
+    req: NextApiRequest,
+    res: NextApiResponse<ClasImportOutput>
+  ) => {
+    const data = req.body as ClasImportInput;
 
-  const {method} = req;
-
-  switch (method) {
-    case "POST":
-      await handleExceptions(res, async () => {
-        const data = req.body as ClasImportInput;
-
-        const result = await clasHandler.importClas(data);
-        return res.status(200).json(result);
-      });
-      return;
-  }
-
-  res.status(405).end(`${method} not allowed`);
-};
+    const result = await clasHandler.importClas(data);
+    return res.status(200).json(result);
+  },
+});

--- a/pages/api/external-repositories/index.ts
+++ b/pages/api/external-repositories/index.ts
@@ -3,24 +3,22 @@ import {NextApiRequest, NextApiResponse} from "next";
 import {TYPES} from "../../../constants/types";
 import {RepositoriesHandler} from "../../../service/handlers/repositories";
 import {ExternalRepository} from "../../../service/domain/repositories";
+import {createAPIHandler} from "../../../pages-common/apiHandler";
 
 const repositoriesHandler = container.get<RepositoriesHandler>(
   TYPES.RepositoriesHandler
 );
 
-export default async (
-  req: NextApiRequest,
-  res: NextApiResponse<ExternalRepository[]>
-) => {
-  const {method} = req;
-
-  switch (method) {
-    case "GET":
-      const repositories = await repositoriesHandler
-        .getAvailableRepositories();
+export default createAPIHandler({
+  GET: {
+    noAuth: true,
+    handler: async (
+      req: NextApiRequest,
+      res: NextApiResponse<ExternalRepository[]>
+    ) => {
+      const repositories =
+        await repositoriesHandler.getAvailableRepositories();
       res.status(200).json(repositories);
-      return;
-  }
-
-  res.status(405).end(`${method} not allowed`);
-};
+    },
+  },
+});

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -1,43 +1,24 @@
 import {NextApiRequest, NextApiResponse} from "next";
-import {ErrorDetails, SafeError} from "../../service/common/web";
 import {container} from "../../service/di";
 import {TYPES} from "../../constants/types";
 import {ServiceSettings} from "../../service/settings";
+import {createAPIHandler} from "../../pages-common/apiHandler";
 
 const settings = container.get<ServiceSettings>(TYPES.ServiceSettings);
-
-/**
- * Executes a given function, handling any thrown SafeError to serve
- * useful information to the client, in case of error.
- *
- * The error class is called "SafeError" because its purpose is to provide
- * error details to the client, unlike unhandled exceptions.
- */
-export async function handleExceptions<T>(
-  res: NextApiResponse<T | ErrorDetails>,
-  action: () => Promise<void>
-): Promise<void> {
-  try {
-    await action();
-  } catch (error) {
-    if (error instanceof SafeError) {
-      // handled error: the service is behaving as desired
-      res.status(error.statusCode).json(error.getObject());
-      return;
-    }
-
-    throw error;
-  }
-}
 
 interface Metadata {
   organizationName: string;
   organizationDisplayName: string;
 }
 
-export default (req: NextApiRequest, res: NextApiResponse<Metadata>) => {
-  res.status(200).json({
-    organizationName: settings.organizationName,
-    organizationDisplayName: settings.organizationDisplayName,
-  });
-};
+export default createAPIHandler({
+  GET: {
+    handler: async (req, res: NextApiResponse<Metadata>) => {
+      res.status(200).json({
+        organizationName: settings.organizationName,
+        organizationDisplayName: settings.organizationDisplayName,
+      });
+    },
+    noAuth: true,
+  },
+});

--- a/pages/api/repositories/[id]/index.ts
+++ b/pages/api/repositories/[id]/index.ts
@@ -1,34 +1,25 @@
 import {container} from "../../../../service/di";
-import {NextApiRequest, NextApiResponse} from "next";
 import {TYPES} from "../../../../constants/types";
-import {handleExceptions} from "../..";
 import {RepositoriesHandler} from "../../../../service/handlers/repositories";
-import {auth} from "../../../../pages-common/auth";
+import {createAPIHandler} from "../../../../pages-common/apiHandler";
 
 const repositoriesHandler = container.get<RepositoriesHandler>(
   TYPES.RepositoriesHandler
 );
 
-export default async (req: NextApiRequest, res: NextApiResponse<any>) => {
-  const {
-    query: {id},
-  } = req;
+export default createAPIHandler({
+  DELETE: async (req, res) => {
+    const {
+      query: {id},
+    } = req;
 
-  if (typeof id !== "string") {
-    // should never happen by definition
-    return res.status(400).end("Invalid object id");
-  }
+    if (typeof id !== "string") {
+      // should never happen by definition
+      return res.status(400).end("Invalid object id");
+    }
 
-  switch (req.method) {
-    case "DELETE":
-      await auth(req, res);
+    await repositoriesHandler.deleteRepositoryConfiguration(id);
 
-      await handleExceptions(res, async () => {
-        await repositoriesHandler.deleteRepositoryConfiguration(id);
-
-        return res.status(204).end();
-      });
-  }
-
-  res.status(405).end(`${req.method} not allowed`);
-};
+    res.status(204).end();
+  },
+});

--- a/pages/api/repositories/index.ts
+++ b/pages/api/repositories/index.ts
@@ -2,36 +2,33 @@ import {container} from "../../../service/di";
 import {NextApiRequest, NextApiResponse} from "next";
 import {TYPES} from "../../../constants/types";
 import {RepositoriesHandler} from "../../../service/handlers/repositories";
-import {handleExceptions} from "..";
-import {auth} from "../../../pages-common/auth";
+import {Repository} from "../../../service/domain/repositories";
+import {createAPIHandler} from "../../../pages-common/apiHandler";
 
 const repositoriesHandler = container.get<RepositoriesHandler>(
   TYPES.RepositoriesHandler
 );
 
-export default async (req: NextApiRequest, res: NextApiResponse<any>) => {
-  const {method} = req;
-
-  switch (method) {
-    case "GET":
-      const repositories = await repositoriesHandler
-        .getConfiguredRepositories();
+export default createAPIHandler({
+  GET: {
+    noAuth: true,
+    handler: async (
+      req: NextApiRequest,
+      res: NextApiResponse<Repository[]>
+    ) => {
+      const repositories =
+        await repositoriesHandler.getConfiguredRepositories();
       res.status(200).json(repositories);
-      return;
-    case "POST":
-      await auth(req, res);
+    },
+  },
+  POST: async (req: NextApiRequest, res: NextApiResponse) => {
+    const {agreementId, repositoryFullName} = req.body;
 
-      await handleExceptions(res, async () => {
-        const {agreementId, repositoryFullName} = req.body;
+    await repositoriesHandler.createRepositoryConfiguration(
+      agreementId,
+      repositoryFullName
+    );
 
-        await repositoriesHandler.createRepositoryConfiguration(
-          agreementId,
-          repositoryFullName
-        );
-        return res.status(204).end();
-      });
-      return;
-  }
-
-  res.status(405).end(`${method} not allowed`);
-};
+    res.status(204).end();
+  },
+});


### PR DESCRIPTION
The previous auth handling function was called inside the api handler, and both sent a response on the `res` object and threw an error to stop further api handler execution when the auth check failed. I think Next.js was trying to handle the thrown error and causing the server to crash since a response had already been sent. 

This PR extracts auth handling (along with request method and safe error handling) into a helper function that wraps the api handler, and can prevent the handler running without needing to throw an error.