### PR TITLE
Add support for PREAPPROVED_GITHUB_ACCOUNTS

### DIFF
--- a/service/domain/checks.ts
+++ b/service/domain/checks.ts
@@ -25,7 +25,8 @@ export class StatusCheckInput {
 export interface StatusChecksService {
   getAllAuthorsByPullRequestId(
     targetRepoFullName: string,
-    pullRequestNumber: number
+    pullRequestNumber: number,
+    preApprovedAccounts: string[]
   ): Promise<string[]>;
 
   createStatus(

--- a/service/handlers/check-cla.ts
+++ b/service/handlers/check-cla.ts
@@ -161,7 +161,8 @@ class ClaCheckHandler {
     const allAuthors = await this._statusCheckService
       .getAllAuthorsByPullRequestId(
         data.repository.fullName,
-        data.pullRequest.number
+        data.pullRequest.number,
+        this._settings.preApprovedAccounts
       );
 
     if (!allAuthors.length) {

--- a/service/settings.ts
+++ b/service/settings.ts
@@ -1,5 +1,5 @@
-import {getEnvSettingOrThrow, getEnvSettingOrDefault} from "./common/settings";
-import {injectable} from "inversify";
+import { getEnvSettingOrThrow, getEnvSettingOrDefault } from "./common/settings";
+import { injectable } from "inversify";
 
 /**
  * Common service settings, not specific to an external service.
@@ -10,6 +10,7 @@ export class ServiceSettings {
   private _secret: string;
   private _organizationName: string;
   private _organizationDisplayName: string;
+  private _preApprovedAccounts: string[];
 
   public get url(): string {
     return this._url;
@@ -27,6 +28,10 @@ export class ServiceSettings {
     return this._organizationDisplayName;
   }
 
+  public get preApprovedAccounts(): string[] {
+    return this._preApprovedAccounts;
+  }
+
   constructor(serverUrl?: string, secret?: string, organizationName?: string) {
     this._url = serverUrl || getEnvSettingOrThrow("SERVER_URL");
     this._secret = secret || getEnvSettingOrThrow("SECRET");
@@ -36,5 +41,9 @@ export class ServiceSettings {
       "ORGANIZATION_DISPLAY_NAME",
       this._organizationName
     );
+    this._preApprovedAccounts = getEnvSettingOrDefault(
+      "PREAPPROVED_GITHUB_ACCOUNTS",
+      ""
+    ).split(",");
   }
 }


### PR DESCRIPTION
This feature allows certain Github usernames to be pre-approved, i.e. to not
require CLAs present in the database for any email. It's especially useful for
bots which create commits (like dependabot) to not trigger the CLA warning.

This is a minimal implementation for now to hotfix an issue in CPython
workflow. Ideally it should be implemented as a database object type.