### PR TITLE
Make username CLA checks case insignificant

### DIFF
--- a/dbschema/migrations/00004.edgeql
+++ b/dbschema/migrations/00004.edgeql
@@ -1,0 +1,8 @@
+CREATE MIGRATION m1mq62xqifdg62gf6oxshidxgnxruewugit5pgsxw6wydiojyytpoq
+    ONTO m1xz5pf3vdfhz2jg7irvfbvlu3lxnw4yrv2i4ycj3ygrkvgq3mcq6a
+{
+  ALTER TYPE default::ContributorLicenseAgreement {
+      CREATE PROPERTY normalized_username := (std::str_lower(.username));
+      CREATE INDEX ON (.normalized_username);
+  };
+};

--- a/dbschema/structure.esdl
+++ b/dbschema/structure.esdl
@@ -93,6 +93,9 @@ module default {
 
         property username -> str;
 
+        property normalized_username := str_lower(.username);
+        index on (.normalized_username);
+
         required property creation_time -> datetime {
             default := datetime_current();
         }

--- a/service/data/edgedb/cla.ts
+++ b/service/data/edgedb/cla.ts
@@ -20,7 +20,9 @@ export class EdgeDBClaRepository
   ): Promise<ContributorLicenseAgreement | null> {
     const ghPseudoEmail = /^(?:[0-9]+)\+([^@]+)@users\.noreply\.github\.com$/;
     const ghPseudoEmailOld = /^([^@+]+)@users\.noreply\.github\.com$/;
-    const ghEmailMatches = email.match(ghPseudoEmail) || email.match(ghPseudoEmailOld);
+    const ghEmailMatches = (
+      email.match(ghPseudoEmail) || email.match(ghPseudoEmailOld)
+    );
     let signed_cla = null;
     if (ghEmailMatches)
     {

--- a/service/data/edgedb/cla.ts
+++ b/service/data/edgedb/cla.ts
@@ -31,7 +31,7 @@ export class EdgeDBClaRepository
             creation_time,
             versionId := .agreement_version.id
           }
-          FILTER .username = <str>$0
+          FILTER .normalized_username = str_lower(<str>$0)
           ORDER BY .email
           LIMIT 1;`,
           [ghEmailMatches[2]]

--- a/service/data/edgedb/cla.ts
+++ b/service/data/edgedb/cla.ts
@@ -18,8 +18,9 @@ export class EdgeDBClaRepository
   async getClaByEmailAddress(
     email: string
   ): Promise<ContributorLicenseAgreement | null> {
-    const ghPseudoEmail = /^([0-9]+)\+([^@]+)@users\.noreply\.github\.com$/;
-    const ghEmailMatches = email.match(ghPseudoEmail);
+    const ghPseudoEmail = /^(?:[0-9]+)\+([^@]+)@users\.noreply\.github\.com$/;
+    const ghPseudoEmailOld = /^([^@+]+)@users\.noreply\.github\.com$/;
+    const ghEmailMatches = email.match(ghPseudoEmail) || email.match(ghPseudoEmailOld);
     let signed_cla = null;
     if (ghEmailMatches)
     {
@@ -34,7 +35,7 @@ export class EdgeDBClaRepository
           FILTER .normalized_username = str_lower(<str>$0)
           ORDER BY .email
           LIMIT 1;`,
-          [ghEmailMatches[2]]
+          [ghEmailMatches[1]]
         );
       });
     }

--- a/service/handlers/sign-cla.ts
+++ b/service/handlers/sign-cla.ts
@@ -56,7 +56,7 @@ class SignClaHandler {
 
   private getAllAuthors(data: ClaCheckInput): string[] {
     if (data.authors) {
-      return data.authors;
+      return data.authors.map(email => email.toLowerCase());
     }
 
     throw new Error("Missing authors information in state.");
@@ -130,10 +130,9 @@ class SignClaHandler {
 
     if (!matchingEmails.length) {
       // The user who signed in is not among those who contributed to the PR
-      // NB: this can also happen if the user has a private email address,
-      // and wants to preserve email privacy when committing.
-      // As of today, it is unclear how this scenario should be handled.
-      //
+      // NB: private email address *are* passed in `getUserEmailAddresses`
+      // as well. Same for the pseudo-emails Github provides for each user
+      // in the form 12345678+USERNAME@users.noreply.github.com.
       throw new SafeError(
         `Thank you for authorizing our application, but the CLA must be signed ` +
           `by the users who contributed to the PR. ` +


### PR DESCRIPTION
Relatedly: support old-style pseudo-GH email addresses without numeric IDs.

Fixes #50 
