### PR TITLE
Modify email normalization to strip `+` and `.`

### DIFF
--- a/dbschema/migrations/00005.edgeql
+++ b/dbschema/migrations/00005.edgeql
@@ -1,0 +1,32 @@
+CREATE MIGRATION m1gibmer4jzdtynetjkyk5iptdavgrgxf5golmpxdm4zmnwvsrvypq
+    ONTO m1mq62xqifdg62gf6oxshidxgnxruewugit5pgsxw6wydiojyytpoq
+{
+  CREATE FUNCTION default::remove_plus_suffix_from_email(email: std::str) ->  std::str USING (WITH
+      parts :=
+          std::str_split(email, '@')
+      ,
+      is_pseudo_email :=
+          ((parts)[-1] = 'users.noreply.github.com')
+      ,
+      no_plus_suffix :=
+          std::re_replace(r'\+.*$', '', (parts)[0])
+      ,
+      no_plus_prefix :=
+          std::re_replace(r'^.*\+', '', (parts)[0])
+  SELECT
+      (((no_plus_prefix IF is_pseudo_email ELSE no_plus_suffix) ++ '@') ++ (parts)[-1])
+  );
+  CREATE FUNCTION default::simplify_gmail_address(email: std::str) ->  std::str USING (WITH
+      parts :=
+          std::str_split(email, '@')
+      ,
+      is_gmail :=
+          ((parts)[-1] = 'gmail.com')
+      ,
+      no_dots :=
+          std::re_replace(r'\.', '', (parts)[0], flags := 'g')
+  SELECT
+      ((no_dots ++ '@gmail.com') IF is_gmail ELSE email)
+  );
+  CREATE FUNCTION default::normalize_email(email: std::str) ->  std::str USING (default::simplify_gmail_address(default::remove_plus_suffix_from_email(std::str_lower(email))));
+};

--- a/dbschema/migrations/00006.edgeql
+++ b/dbschema/migrations/00006.edgeql
@@ -1,0 +1,9 @@
+CREATE MIGRATION m1fmqcwgzvkve5zaexz2qzd326ilc4xem2lrebzhsqhtrfv3iyhkza
+    ONTO m1gibmer4jzdtynetjkyk5iptdavgrgxf5golmpxdm4zmnwvsrvypq
+{
+  ALTER TYPE default::ContributorLicenseAgreement {
+      ALTER PROPERTY normalized_email {
+          USING (default::normalize_email(.email));
+      };
+  };
+};

--- a/dbschema/structure.esdl
+++ b/dbschema/structure.esdl
@@ -114,7 +114,7 @@ module default {
         };
         index on (.email);
 
-        property normalized_email := str_lower(.email);
+        property normalized_email := normalize_email(.email);
         constraint exclusive on (.normalized_email);
         index on (.normalized_email);
 

--- a/dbschema/structure.esdl
+++ b/dbschema/structure.esdl
@@ -81,6 +81,33 @@ module default {
         required link agreement -> Agreement;
     }
 
+    function remove_plus_suffix_from_email(email: str) -> str using (
+        with
+            parts := str_split(email, '@'),
+            is_pseudo_email := parts[-1] = 'users.noreply.github.com',
+            no_plus_suffix := re_replace(r'\+.*$', '', parts[0]),
+            no_plus_prefix := re_replace(r'^.*\+', '', parts[0])
+        select
+            (no_plus_prefix if is_pseudo_email else no_plus_suffix) ++ '@' ++ parts[-1]
+    );
+
+    function simplify_gmail_address(email: str) -> str using (
+        with
+          parts := str_split(email, '@'),
+          is_gmail := parts[-1] = 'gmail.com',
+          no_dots := re_replace(r'\.', '', parts[0], flags := 'g')
+        select
+          no_dots ++ '@gmail.com' if is_gmail else email
+    );
+
+    function normalize_email(email: str) -> str using (
+        simplify_gmail_address(
+            remove_plus_suffix_from_email(
+                str_lower(email)
+            )
+        )
+    );
+
     type ContributorLicenseAgreement {
         required property email -> str {
             constraint exclusive;

--- a/scripts/export-import/deduplicate.py
+++ b/scripts/export-import/deduplicate.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+"""
+Deduplicate the database's entries that should be the same normalized email.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import time
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+import edgedb
+from edgedb.pgproto import pgproto
+from rich.console import Console
+from rich.progress import Progress
+from rich.prompt import Prompt
+
+
+load_dotenv()
+
+DATABASE_URL = os.environ["DATABASE_URL"]
+EDGEDB_PASSWORD = urlparse(DATABASE_URL).password
+
+
+class RollBack(Exception):
+    """Indicates we want to roll a transaction back."""
+
+
+console = Console()
+print = console.print
+
+
+print("Connecting to EdgeDB", end="... ")
+con = edgedb.create_client(
+    host="localhost",
+    user="edgedb",
+    database="edgedb",
+    password=EDGEDB_PASSWORD,
+)
+print("connected.")
+atexit.register(con.close)
+
+NormEmail = str
+ID = pgproto.UUID
+seen: dict[NormEmail, set[ID]] = {}
+to_delete: set[ID] = set()
+
+with Progress(console=console, transient=True) as progress:
+    result = con.query(
+        """
+        SELECT ContributorLicenseAgreement {
+            id,
+            email,
+            norm_email := normalize_email(.email)
+        }
+        ORDER BY .creation_time;
+        """,
+    )
+    task = progress.add_task("Processing", total=len(result))
+    for elem in result:
+        if elem.norm_email in seen:
+            to_delete.add((elem.id, elem.norm_email))
+        seen.setdefault(elem.norm_email, set()).add(elem.id)
+        progress.advance(task)
+
+print(f"Seen {len(seen)} normalized emails.")
+print(f"Should delete {len(to_delete)} duplicates.")
+
+try:
+    for tx in con.transaction():
+        with tx:
+            with Progress(console=console, transient=True) as progress:
+                task = progress.add_task("Deleting duplicates", total=len(to_delete))
+                for elem_id, elem_email in sorted(to_delete):
+                    print(elem_email)
+                    tx.query(
+                        """
+                        DELETE ContributorLicenseAgreement
+                        FILTER .id = <uuid>$id;
+                        """,
+                        id=elem_id,
+                    )
+                    progress.advance(task)
+            if to_delete:
+                answer = Prompt.ask("Commit deletion? (y/N)")
+                if answer.lower() != "y":
+                    print("Aborting.")
+                    raise RollBack
+except RollBack:
+    pass

--- a/service/data/edgedb/cla.ts
+++ b/service/data/edgedb/cla.ts
@@ -51,7 +51,7 @@ export class EdgeDBClaRepository
             creation_time,
             versionId := .agreement_version.id
           }
-          FILTER .normalized_email = str_lower(<str>$0)));`,
+          FILTER .normalized_email = normalize_email(<str>$0)));`,
           [email]
         );
       });


### PR DESCRIPTION
+suffixes are removed for all emails except for @users.noreply.github.com special addresses, in which case prefixes+ are removed as the usernames are used by the CLA bot.

Dot characters are removed from gmail.com addresses where they are irrelevant.

**Note:** changing `ContributorLicenseAgreement.normalized_email` to actually use the `normalize_email()` function is left in a separate commit because an action that deduplicates the database might be necessary to apply the migration successfully. A script to do that is added to `scripts/`.

Fixes edgedb/cla-bot#51