### PR TITLE
Drop email validation

### DIFF
--- a/components/admin/administrators/administrator-new.tsx
+++ b/components/admin/administrators/administrator-new.tsx
@@ -4,7 +4,6 @@ import ErrorPanel from "../../common/error";
 import Loader from "../../common/loader";
 import {changeHandler} from "../../forms";
 import {post} from "../../fetch";
-import {validateEmail} from "../../../service/common/emails";
 import {ApplicationError} from "../../errors";
 
 interface NewAdministratorFormProps {
@@ -47,16 +46,6 @@ export default class NewAdministratorForm extends Component<
       this.setState({
         emailError: true,
         emailHelperText: "Please insert a value",
-      });
-      anyError = true;
-    }
-
-    if (!validateEmail(email.trim())) {
-      this.setState({
-        emailError: true,
-        emailHelperText:
-          "The value is not a valid email address. " +
-          "A single address is supported.",
       });
       anyError = true;
     }

--- a/components/admin/clas/clas-import.tsx
+++ b/components/admin/clas/clas-import.tsx
@@ -14,7 +14,6 @@ import FileExamples, {FileExample} from "../../common/forms/file-examples";
 import {Button, TextField} from "@material-ui/core";
 import {AgreementListItem} from "../agreements/contracts";
 import DynamicSelect from "../../common/forms/select-named-dynamic";
-import {validateEmail} from "../../../service/common/emails";
 import CheckCircleOutlineIcon from "@material-ui/icons/CheckCircleOutline";
 import ErrorOutline from "@material-ui/icons/ErrorOutline";
 import NotInterestedIcon from "@material-ui/icons/NotInterested";
@@ -253,10 +252,6 @@ export class ClasImport extends Component<{}, ClasImportState> {
   }
 
   validateItem(entry: ImportUIEntry): void {
-    if (!validateEmail(entry.email)) {
-      entry.emailError = true;
-      entry.emailHelperText = "The email address is invalid";
-    }
     if (!entry.username) {
       entry.usernameError = true;
       entry.usernameHelperText = "Missing username";

--- a/components/admin/clas/clas-search.tsx
+++ b/components/admin/clas/clas-search.tsx
@@ -5,7 +5,6 @@ import {Component, ReactElement} from "react";
 import {ContributorLicenseAgreement} from "./contracts";
 import ErrorPanel from "../../common/error";
 import Loader from "../../common/loader";
-import {validateEmail} from "../../../service/common/emails";
 import {ApplicationError} from "../../errors";
 import {get} from "../../fetch";
 
@@ -44,14 +43,6 @@ export class ClaSearch extends Component<{}, ClaSearchState> {
     }
 
     search = search.trim();
-
-    if (!validateEmail(search)) {
-      this.setState({
-        searchError: true,
-        searchHelperText: "The value is not a valid email address.",
-      });
-      return;
-    }
 
     this.setState({
       waiting: true,

--- a/service/common/emails.ts
+++ b/service/common/emails.ts
@@ -1,9 +1,0 @@
-/**
- * Validates a single email address value.
- */
-export function validateEmail(value: string): boolean {
-  /* tslint:disable-next-line */
-  return /^([a-zA-Z0-9_\-\.\+]+)@([a-zA-Z0-9_\-\.\+]+)\.([a-zA-Z]{2,5}){1,25}$/.test(
-    value
-  );
-}

--- a/service/handlers/administrators.ts
+++ b/service/handlers/administrators.ts
@@ -5,7 +5,6 @@ import type {
   AdministratorsRepository,
 } from "../domain/administrators";
 import {BadRequestError, UnauthorizedError} from "../common/web";
-import {validateEmail} from "../common/emails";
 import type {UsersService} from "../domain/users";
 import {TokensHandler} from "./tokens";
 import type {OrganizationsService} from "../domain/organizations";
@@ -34,16 +33,6 @@ export class AdministratorsHandler {
     if (!email || !email.trim()) throw new BadRequestError("Missing email");
 
     email = email.trim();
-
-    // Note: it was taken into consideration to support multiple email
-    // addresses in a single web request and comma separated,
-    // but it makes much for much more complex error handling: for example
-    // to handle partial failures, conflicts, etc.
-    // For this version of the application, administrators can be inserted
-    // one at a time.
-    if (!validateEmail(email)) {
-      throw new BadRequestError("Invalid email address");
-    }
 
     // TODO: it would be nice to send an invitation email to new
     // administrators (out of the scope of the MVP)

--- a/service/handlers/clas.ts
+++ b/service/handlers/clas.ts
@@ -8,7 +8,6 @@ import {
   ClasImportOutput,
   ClasImportEntryResult,
 } from "../domain/cla";
-import {validateEmail} from "../common/emails";
 import {type AgreementsRepository} from "../domain/agreements";
 import {v4 as uuid} from "uuid";
 import {ImportEntry} from "../../components/admin/clas/contracts";
@@ -32,12 +31,6 @@ export class ClasHandler {
   async getClaByEmail(
     email: string
   ): Promise<ContributorLicenseAgreement | null> {
-    if (!validateEmail(email)) {
-      throw new BadRequestError(
-        "The given value is not a valid email address"
-      );
-    }
-
     return await this._clasRepository.getClaByEmailAddress(email);
   }
 
@@ -65,16 +58,6 @@ export class ClasHandler {
     const results: ClasImportEntryResult[] = [];
     for (const entry of data.entries) {
       try {
-        // validate email
-        if (!validateEmail(entry.email)) {
-          results.push({
-            success: false,
-            entry: simplifyEntry(entry),
-            error: "Invalid email",
-          });
-          continue;
-        }
-
         await this._clasRepository.saveCla({
           id: uuid(),
           email: entry.email.trim().toLowerCase(),


### PR DESCRIPTION
Email validation is a fool's errand and doesn't really serve any meaningful
purpose, since the bot treats emails as unique identifiers and does not send
any emails.

Fixes: #47
