### PR TITLE
Fix filter warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cross-env": "^7.0.3",
     "csv-parse": "^5.6.0",
     "dotenv": "^16.4.7",
-    "gel": "^2.0.0",
+    "gel": "^2.1.0",
     "immer": "^10.1.1",
     "inversify": "^5.1.1",
     "jsonwebtoken": "^9.0.2",

--- a/service/data/edgedb/administrators.ts
+++ b/service/data/edgedb/administrators.ts
@@ -48,8 +48,8 @@ export class EdgeDBAdministratorsRepository
   async removeAdministrator(id: string): Promise<void> {
     await this.run(async (connection) => {
       await e
-        .delete(e.Administrator, (a) => ({
-          filter: e.op(a.id, "=", e.uuid(id)),
+        .delete(e.Administrator, () => ({
+          filter_single: {id},
         }))
         .run(connection);
     });

--- a/service/data/edgedb/agreements.ts
+++ b/service/data/edgedb/agreements.ts
@@ -72,8 +72,8 @@ export class EdgeDBAgreementsRepository
   ): Promise<void> {
     await this.run(async (connection) =>
       e
-        .update(e.Agreement, (agreement) => ({
-          filter: e.op(agreement.id, "=", e.uuid(id)),
+        .update(e.Agreement, () => ({
+          filter_single: {id},
           set: {
             name,
             description,
@@ -91,8 +91,8 @@ export class EdgeDBAgreementsRepository
   ): Promise<void> {
     await this.run(async (connection) =>
       e
-        .update(e.AgreementText, (text) => ({
-          filter: e.op(text.id, "=", e.uuid(id)),
+        .update(e.AgreementText, () => ({
+          filter_single: {id},
           set: {
             title,
             text: body,
@@ -106,8 +106,8 @@ export class EdgeDBAgreementsRepository
   async updateAgreementVersion(id: string, draft: boolean): Promise<void> {
     await this.run(async (connection) =>
       e
-        .update(e.AgreementVersion, (ver) => ({
-          filter: e.op(ver.id, "=", e.uuid(id)),
+        .update(e.AgreementVersion, () => ({
+          filter_single: {id},
           set: {
             draft,
           },
@@ -119,20 +119,16 @@ export class EdgeDBAgreementsRepository
   async getCurrentAgreementVersionForRepository(
     repositoryFullName: string
   ): Promise<RepositoryAgreementInfo | null> {
-    const Version = e.assert_single(
-      e.select(e.AgreementVersion, (v) => {
-        const ver = v["<versions[is Agreement]"];
-        const repo = ver["<agreement[is Repository]"];
-
-        return {
-          filter: e.op(
-            e.op(v.current, "and", e.op(v.texts.culture, "=", "en")),
-            "and",
-            e.op(repo.full_name, "=", repositoryFullName)
-          ),
-        };
-      })
-    );
+    const Repo = e.select(e.Repository, () => ({
+      filter_single: {full_name: repositoryFullName},
+    }));
+    const Version = e.select(Repo.agreement.versions, (v) => ({
+      filter_single: e.op(
+        v.current,
+        "and",
+        e.any(e.op(v.texts.culture, "=", "en"))
+      ),
+    }));
 
     return await this.run(async (connection) =>
       e
@@ -147,21 +143,15 @@ export class EdgeDBAgreementsRepository
     repositoryFullName: string,
     cultureCode: string
   ): Promise<AgreementText | null> {
-    const Text = e.assert_single(
-      e.select(e.AgreementText, (text) => {
-        const ver = text["<texts[is AgreementVersion]"];
-        const agr = ver["<versions[is Agreement]"];
-        const repo = agr["<agreement[is Repository]"];
-
-        return {
-          filter: e.op(
-            e.op(e.op(text.culture, "=", cultureCode), "and", ver.current),
-            "and",
-            e.op(repo.full_name, "=", repositoryFullName)
-          ),
-        };
-      })
-    );
+    const Repo = e.select(e.Repository, () => ({
+      filter_single: {full_name: repositoryFullName},
+    }));
+    const CurrentVersion = e.select(Repo.agreement.versions, (ver) => ({
+      filter_single: ver.current,
+    }));
+    const Text = e.select(CurrentVersion.texts, (text) => ({
+      filter_single: e.op(text.culture, "=", cultureCode),
+    }));
 
     return await this.run(async (connection) =>
       e
@@ -182,17 +172,11 @@ export class EdgeDBAgreementsRepository
     versionId: string,
     cultureCode: string
   ): Promise<AgreementText | null> {
-    const Text = e.assert_single(
-      e.select(e.AgreementText, (text) => {
-        const ver = text["<texts[is AgreementVersion]"];
-
-        return {
-          filter: e.op(
-            e.op(text.culture, "=", cultureCode),
-            "and",
-            e.op(ver.id, "=", e.uuid(versionId))
-          ),
-        };
+    const Text = e.select(
+      e.select(e.AgreementVersion, () => ({filter_single: {id: versionId}}))
+        .texts,
+      (text) => ({
+        filter_single: e.op(text.culture, "=", cultureCode),
       })
     );
 
@@ -232,7 +216,7 @@ export class EdgeDBAgreementsRepository
           name: true,
           description: true,
           creationTime: agreement.creation_time,
-          filter: agreement.versions.current,
+          filter: e.any(agreement.versions.current),
         }))
         .run(connection)
     );
@@ -319,8 +303,8 @@ export class EdgeDBAgreementsRepository
         }),
       });
 
-      const Update = e.update(e.Agreement, (agreement) => ({
-        filter: e.op(agreement.id, "=", e.uuid(agreementId)),
+      const Update = e.update(e.Agreement, () => ({
+        filter_single: {id: agreementId},
         set: {
           versions: {
             "+=": Version,

--- a/service/data/edgedb/cla.ts
+++ b/service/data/edgedb/cla.ts
@@ -20,41 +20,41 @@ export class EdgeDBClaRepository
     if (ghEmailMatches) {
       signed_cla = await this.run(async (connection) =>
         e
-          .assert_single(
-            e.select(e.ContributorLicenseAgreement, (a) => ({
-              id: true,
-              email: true,
-              username: true,
-              signedAt: a.creation_time,
-              versionId: a.agreement_version.id,
+          .select(e.ContributorLicenseAgreement, (a) => ({
+            id: true,
+            email: true,
+            username: true,
+            signedAt: a.creation_time,
+            versionId: a.agreement_version.id,
 
-              filter: e.op(
-                a.normalized_username,
-                "=",
-                e.str_lower(ghEmailMatches[1])
-              ),
+            filter_single: e.op(
+              a.normalized_username,
+              "=",
+              e.str_lower(ghEmailMatches[1])
+            ),
 
-              order_by: a.email,
+            order_by: a.email,
 
-              limit: 1,
-            }))
-          )
+            limit: 1,
+          }))
           .run(connection)
       );
     } else {
       signed_cla = await this.run(async (connection) =>
         e
-          .assert_single(
-            e.select(e.ContributorLicenseAgreement, (a) => ({
-              id: true,
-              email: true,
-              username: true,
-              signedAt: a.creation_time,
-              versionId: a.agreement_version.id,
+          .select(e.ContributorLicenseAgreement, (a) => ({
+            id: true,
+            email: true,
+            username: true,
+            signedAt: a.creation_time,
+            versionId: a.agreement_version.id,
 
-              filter: e.op(a.normalized_email, "=", e.normalize_email(email)),
-            }))
-          )
+            filter_single: e.op(
+              a.normalized_email,
+              "=",
+              e.normalize_email(email)
+            ),
+          }))
           .run(connection)
       );
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -364,9 +364,9 @@
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
 "@gel/generate@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@gel/generate/-/generate-0.6.0.tgz#cbf77e4aea9f86c5e14c51eab1870c08b893c2e2"
-  integrity sha512-p1qiR/JHNM52GCp19aes2Nwt2gzz0juJu6xaXFQyT1nyAdjIBfiy9j/JNxEM9xvfXUjv/yf3OiEk9Rq7zJjLHg==
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@gel/generate/-/generate-0.6.2.tgz#5b273974045ead31fcfce870ae0080e850d6692b"
+  integrity sha512-Ew+lDLPi1wRyH7XhmUzDAYDGQ4Eu8pgP5DoIvCKPbc/uQYc2zIrTkaxGzoPN5MV+TwqgUNOvthW/38vzP0+/GA==
   dependencies:
     "@iarna/toml" "^2.2.5"
     debug "^4.3.4"
@@ -1760,10 +1760,10 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-gel@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/gel/-/gel-2.0.0.tgz#d3627bcd2c769fe475ed1f28fc433660acc83371"
-  integrity sha512-Oq3Fjay71s00xzDc0BF/mpcLmnA+uRqMEJK8p5K4PaZjUEsxaeo+kR9OHBVAf289/qPd+0OcLOLUN0UhqiUCog==
+gel@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/gel/-/gel-2.1.0.tgz#8b15912d7dc1f8ec2ad8602a7313ab2fa632eb6a"
+  integrity sha512-HCeRqInCt6BjbMmeghJ6BKeYwOj7WJT5Db6IWWAA3IMUUa7or7zJfTUEkUWCxiOtoXnwnm96sFK9Fr47Yh2hOA==
   dependencies:
     "@petamoriken/float16" "^3.8.7"
     debug "^4.3.4"


### PR DESCRIPTION
Some queries are causing `possibly more than one element returned by an expression in a FILTER clause` warnings, so these have been either refactored to (hopefully) not possibly return more than one element or wrapped in `any` where multiple possible elements is intended. While here a few `filter_single` expressions on exclusive props have also been updated to not use the `e.op` syntax (removes the need for the querybuilder to add an uneeded `assert_single`).